### PR TITLE
ASDPLNG-100: Switch to defining puppet yum repo

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -28,11 +28,10 @@ The following parameters are available in the `profile_puppet_agent` class:
 
 * [`absent_packages`](#absent_packages)
 * [`packages`](#packages)
-* [`repo_rpm_name`](#repo_rpm_name)
-* [`repo_rpm_url`](#repo_rpm_url)
 * [`service_enabled`](#service_enabled)
 * [`service_name`](#service_name)
 * [`service_running`](#service_running)
+* [`yumrepo`](#yumrepo)
 
 ##### <a name="absent_packages"></a>`absent_packages`
 
@@ -45,18 +44,6 @@ Array of package names to ensure absent
 Data type: `Array[ String ]`
 
 Array of package names to install
-
-##### <a name="repo_rpm_name"></a>`repo_rpm_name`
-
-Data type: `String`
-
-String of package name for puppet repo package
-
-##### <a name="repo_rpm_url"></a>`repo_rpm_url`
-
-Data type: `String`
-
-String of URL for puppet repo package
 
 ##### <a name="service_enabled"></a>`service_enabled`
 
@@ -75,4 +62,10 @@ String of the name of the puppet agent service
 Data type: `Boolean`
 
 Boolean to determine if the puppet agent service is ensured running
+
+##### <a name="yumrepo"></a>`yumrepo`
+
+Data type: `Hash`
+
+Hash of yumrepo resource for puppet yum repository
 

--- a/data/os/RedHat.yaml
+++ b/data/os/RedHat.yaml
@@ -1,7 +1,14 @@
 ---
 profile_puppet_agent::absent_packages:
+  - "puppet-release"
   - "puppet5-release"
   - "puppetlabs-release-pc1"
 profile_puppet_agent::packages:
   - "puppet-agent"
-profile_puppet_agent::repo_rpm_name: "puppet-release"
+profile_puppet_agent::yumrepo:
+  puppet:
+    baseurl: "https://yum.puppetlabs.com/puppet/el/$releasever/$basearch"
+    descr: "Puppet Repository el $releasever - $basearch"
+    enabled: 1
+    gpgcheck: 1
+    gpgkey: "https://yum.puppet.com/RPM-GPG-KEY-puppet-20250406"

--- a/data/os/RedHat/7.yaml
+++ b/data/os/RedHat/7.yaml
@@ -1,2 +1,0 @@
----
-profile_puppet_agent::repo_rpm_url: "https://yum.puppetlabs.com/puppet-release-el-7.noarch.rpm"

--- a/data/os/RedHat/8.yaml
+++ b/data/os/RedHat/8.yaml
@@ -1,2 +1,0 @@
----
-profile_puppet_agent::repo_rpm_url: "https://yum.puppetlabs.com/puppet-release-el-8.noarch.rpm"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,12 +6,6 @@
 # @param packages
 #   Array of package names to install
 #
-# @param repo_rpm_name
-#   String of package name for puppet repo package
-#
-# @param repo_rpm_url
-#   String of URL for puppet repo package
-#
 # @param service_enabled
 #   Boolean to determine if the puppet agent service is enabled
 #
@@ -21,17 +15,19 @@
 # @param service_running
 #   Boolean to determine if the puppet agent service is ensured running
 #
+# @param yumrepo
+#   Hash of yumrepo resource for puppet yum repository
+#
 # @example
 #   include profile_puppet_agent
 class profile_puppet_agent
 (
   Array[ String ] $absent_packages,
   Array[ String ] $packages,
-  String          $repo_rpm_name,
-  String          $repo_rpm_url,
   Boolean         $service_enabled,
   String          $service_name,
   Boolean         $service_running,
+  Hash            $yumrepo,
 ) {
 
   $absent_packages_defaults = {
@@ -40,13 +36,13 @@ class profile_puppet_agent
   # Ensure the resources
   ensure_packages( $absent_packages, $absent_packages_defaults )
 
-  package { $repo_rpm_name:
-    source   => $repo_rpm_url,
-    provider => 'rpm',
+  $yumrepo_defaults = {
+    ensure  => present,
+    enabled => true,
   }
+  ensure_resources( 'yumrepo', $yumrepo, $yumrepo_defaults )
 
   $packages_defaults = {
-    require => Package[$repo_rpm_name],
   }
   ensure_packages( $packages, $packages_defaults )
 


### PR DESCRIPTION
…instead of installing puppet-release RPM from internet

Besides being simpler, this also gets around the fact that we can't install direct RPMs easily when on private subnets. Yum supports httpproxy in its config -- there is nothing similar for RPM installs. It is interesting that Puppet package resource under EL8 appears to install RPMs via the `yum` command, while under EL7 it simply uses `rpm` command.