### PR TITLE
SVC-3960: Fix Puppet agent monitoring permissions

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -27,6 +27,8 @@ include profile_puppet_agent
 The following parameters are available in the `profile_puppet_agent` class:
 
 * [`absent_packages`](#absent_packages)
+* [`config`](#config)
+* [`config_file`](#config_file)
 * [`packages`](#packages)
 * [`service_enabled`](#service_enabled)
 * [`service_name`](#service_name)
@@ -38,6 +40,18 @@ The following parameters are available in the `profile_puppet_agent` class:
 Data type: `Array[ String ]`
 
 Array of package names to ensure absent
+
+##### <a name="config"></a>`config`
+
+Data type: `Array[ Hash ]`
+
+Array of puppet agent config hashes for puppet_agent::config
+
+##### <a name="config_file"></a>`config_file`
+
+Data type: `String`
+
+Full path to puppet config file
 
 ##### <a name="packages"></a>`packages`
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,4 +1,9 @@
 ---
+profile_puppet_agent::config:
+  - "section": ""
+    "setting": "lastrunfile"
+    "value": "$publicdir/last_run_summary.yaml { owner = root, group = service, mode = 0644 }"
+profile_puppet_agent::config_file: "/etc/puppetlabs/puppet/puppet.conf"
 profile_puppet_agent::service_enabled: true
 profile_puppet_agent::service_name: "puppet"
 profile_puppet_agent::service_running: true

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,6 +3,12 @@
 # @param absent_packages
 #   Array of package names to ensure absent
 #
+# @param config
+#   Array of puppet agent config hashes for puppet_agent::config
+#
+# @param config_file
+#   Full path to puppet config file
+#
 # @param packages
 #   Array of package names to install
 #
@@ -23,12 +29,17 @@
 class profile_puppet_agent
 (
   Array[ String ] $absent_packages,
+  Array[ Hash ]   $config,
+  String          $config_file,
   Array[ String ] $packages,
   Boolean         $service_enabled,
   String          $service_name,
   Boolean         $service_running,
   Hash            $yumrepo,
 ) {
+
+  ## IN THE FUTURE WE MAY WANT TO EXPLORE USING 
+  ## https://github.com/puppetlabs/puppetlabs-puppet_agent/
 
   $absent_packages_defaults = {
     ensure  => purged,
@@ -49,6 +60,23 @@ class profile_puppet_agent
   service { $service_name:
     ensure => $service_running,
     enable => $service_enabled,
+  }
+
+  # LOGIC COPIED FROM 
+  # https://github.com/puppetlabs/puppetlabs-puppet_agent/blob/main/manifests/configure.pp
+  $config.each |$item| {
+    $ensure = $item['ensure'] ? {
+      undef   => present,
+      default => $item['ensure'],
+    }
+
+    ini_setting { "puppet-${item['section']}-${item['setting']}":
+      ensure  => $ensure,
+      section => $item['section'],
+      setting => $item['setting'],
+      value   => $item['value'],
+      path    => $config_file,
+    }
   }
 
 }


### PR DESCRIPTION
See https://jira.ncsa.illinois.edu/browse/SVC-3960

This is being test on the following hosts:
- asd-pup
- asd-test-afs01
- asd-test-centos7a
- asd-test-rhel8a
- asd-test-web1
- nile-vm

See https://metrics.ncsa.illinois.edu/d/-moZfmziz/puppet-health for the monitoring.