### PR TITLE
SVCPLAN-1236: Set specific releasever for RedHat 7 puppet yum repo

### DIFF
--- a/data/os/RedHat/7.yaml
+++ b/data/os/RedHat/7.yaml
@@ -1,0 +1,8 @@
+---
+profile_puppet_agent::yumrepo:
+  puppet:
+    baseurl: "https://yum.puppetlabs.com/puppet/el/7/$basearch"
+    descr: "Puppet Repository el 7 - $basearch"
+    enabled: 1
+    gpgcheck: 1
+    gpgkey: "https://yum.puppet.com/RPM-GPG-KEY-puppet-20250406"


### PR DESCRIPTION
Apparently RHEL 7 sets the `$releasever` in YUM to be `7Server` instead of just the number `7`. CentOS 7-8 & RHEL 8-9 appear to all just use the number of the version. 

The Puppet YUM repos at https://yum.puppetlabs.com/puppet/el/ do not have a path that matches https://yum.puppetlabs.com/puppet/el/7Server/ . So `puppet.repo` on RHEL 7 needs to not reference `$releasever` and instead hard code the release version specifically.

This has been tested on `control-test-rhel7a` & `control-test-rhel7b`.